### PR TITLE
Consolidate Cafes API 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             - data:/usr/src/data
         ports:
             - "3000:3000"
-        command: ["./wait-for-it.sh", "-t", "60`", "db:5432", "--", "npm", "start"]
+        command: ["./wait-for-it.sh", "-t", "60", "db:5432", "--", "npm", "start"]
 
 volumes:
     data: {}

--- a/server/routes/cafes.js
+++ b/server/routes/cafes.js
@@ -4,131 +4,59 @@ var util = require('../util');
 var knex = require('../database');
 var st = require('knex-postgis')(knex);
 
-function getAllPoints(tableName) {
-  return (req, res, next) => {
-    /*
-    Form query:
-
-    select name, point, ST_Distance(
-      point,
-      'SRID=4326;Point(121.5618483 25.0376636)'
-    ) as distance
-    from cafes;
-    */
-    knex.select('*')
-    .from(tableName)
-    .then((data) => util.dbGeoParse(data))
-    .then((output) => {
-      res.send(output)
-    })
-    .catch((err) => {
-      res.send(err);
-    })
+function query(tableName, parameters) {
+  // Return all cafes if no location to query
+  if (!parameters.location) {
+    return knex.select('*').from(tableName)
   }
+
+  let location = parameters.location
+  let radius = parameters.radius || 1000
+  let limit = parameters.limit || 20
+
+  // Convert valid location to latitude and longitude
+  var lat, lng;
+  if (util.pointParamValid(location)) {
+    [lat, lng] = util.pointFromParam(location);
+  } else {
+    throw `Invalid point parameter ${location}`;
+  }
+
+  console.log(`Requesting ${limit} ${tableName} within ${radius} meters from lat: ${lat}, lng: ${lng})`);
+
+  let wkt = `Point(${lng} ${lat})`;
+  let geogPoint = st.geography('point');
+  let geogWkt = st.geography(st.geomFromText(wkt, 4326));
+
+  return knex.select('*', st.distance(geogPoint, geogWkt).as('distance'))
+  .from(tableName)
+  .where(st.dwithin(geogPoint, geogWkt, radius))
+  .orderByRaw(`point <-> 'SRID=4326;${wkt}'`)
+  .limit(limit);
 }
 
-function getKNearestPoints(tableName) {
+function getWithQuery(tableName) {
   return (req, res, next) => {
-    let point = req.params['point'];
-    let k = req.params['k'];
-    var lat, lng;
-    // Check point
-    if (util.pointParamValid(point)) {
-      [lat, lng] = util.pointFromParam(point);
-    } else {
-      res.send(`Invalid point parameter ${point}`);
+    let parameters = {
+      location: req.query.location,
+      radius: req.query.radius,
+      limit: req.query.limit
     }
 
-    console.log(`Requesting ${tableName} around (${lat}, ${lng})`);
-
-    /*
-    Form query:
-
-    select name, point, ST_Distance(
-      point,
-      'SRID=4326;Point(121.5618483 25.0376636)'
-    ) as distance
-    from cafes
-    order by
-      point <->
-      'SRID=4326;Point(121.5618483 25.0376636)'
-    limit 10;
-    */
-    let wkt = `Point(${lng} ${lat})`;
-    knex.select('name', 'point', st.distance(st.geography('point'), st.geography(st.geomFromText(wkt, 4326))).as('distance'))
-    .from(tableName)
-    .orderByRaw(`point <-> 'SRID=4326;${wkt}'`)
-    .limit(k)
-    .then((data) => util.dbGeoParse(data))
-    .then((output) => {
-      res.send(output)
-    })
-    .catch((err) => {
-      res.send(err);
-    })
-  }
-}
-
-function withinRadiusPoints(tableName) {
-  return (req, res, next) => {
-    let point = req.params['point'];
-    var radius = req.params['radius'];
-    var lat, lng;
-
-    // Check point
-    if (util.pointParamValid(point)) {
-      [lat, lng] = util.pointFromParam(point);
-    } else {
-      res.send(`Invalid point parameter ${point}`);
-    }
-
-    console.log(`Requesting ${tableName} within ${radius} meters from lat: ${lat}, lng: ${lng})`);
-
-    /*
-    Form query:
-
-    select name, point, ST_Distance(
-      point,
-      'SRID=4326;Point(121.5618483 25.0376636)'
-    ) as distance
-    from cafes
-    where ST_DWithin(
-      point::geography,
-      'SRID=4326;Point(121.5618483 25.0376636)'::geography,
-      600
-    );
-    */
-
-    let wkt = `Point(${lng} ${lat})`;
-    let geogPoint = st.geography('point');
-    let geogWkt = st.geography(st.geomFromText(wkt, 4326));
-    knex.select('name', 'point', st.distance(geogPoint, geogWkt).as('distance'))
-    .from(tableName)
-    .where(st.dwithin(geogPoint, geogWkt, radius))
-    .then((data) => util.dbGeoParse(data))
-    .then((output) => {
-      res.send(output)
-    })
-    .catch((err) => {
-      res.send(err);
-    })
+    query(tableName, parameters)
+      .then((data) => util.dbGeoParse(data))
+      .then((output) => {
+        res.send(output)
+      })
+      .catch((err) => {
+        res.send(err);
+      })
   }
 }
 
 /*
-  All locations
+  Endpoint
 */
-router.get('/', getAllPoints('cafes'));
-
-/*
-  Within distance
-*/
-router.get('/:point/within/:radius', withinRadiusPoints('cafes'));
-
-/*
-  GET cafes api
-  Returns info for the `k` closest cafes from coordinate `point`
-*/
-router.get('/:point/nearest/:k', getKNearestPoints('cafes'));
+router.get('/', getWithQuery('cafes'));
 
 module.exports = router;


### PR DESCRIPTION
## Description

Instead of having three endpoints
1. `/cafes`
2. `/cafes/:point/within/:radius`
3. `/cafes/:point/nearest/:k`

We now have a single endpoint for each type of service (cafes, ubike station, etc). The different criteria for search is now defined with queries as follows

### `GET /cafes`


| Parameter | Description |
|------------| ------------|
| location     | Location of reference. Must be in the form of "@{latitude},{longitude}" |
| radius        | Integer in meters |
| limit           | Number of points that should be returned |


### Example

``` 
# Get all cafes
GET /cafes

# Get cafes within 600 meter radius of coordinate (25.042, 121.54654)
GET /cafes?location=@25.042,121.54654&radius=600

# Get 20 closest cafes from coordinate (25.042, 121.54654)
GET /cafes?location=@25.042,121.54654&limit=20

# Get 20 closest cafes within 600 meter radius of coordinate (25.042, 121.54654)
GET /cafes?location=@25.042,121.54654&radius=600&limit=20
```

## Changes

- Fixed a typo in `docker-compse.yml` that causes error in setting timeout
- Removed separate methods for previous endpoints and consolidated them into a single query
- Added helper method that accepts query parameters for the query

